### PR TITLE
TCEC Season 20 Superfinal submission

### DIFF
--- a/gpu/LCZero_GPU.json
+++ b/gpu/LCZero_GPU.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "LCZero v0.26.3_T60.SV.JH.94-100",
+        "name": "LCZero PR1483_T60.SV.JH.94-100",
         "command": "../gpu_engine.sh ./lc0 --show-hidden",
         "restart": "on",
         "rating": "3542",

--- a/gpu/LCZero_GPU.json
+++ b/gpu/LCZero_GPU.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "LCZero PR1483_T60.SV.JH.94-100",
+        "name": "LCZero v0.26.3+Tilps/dje_magic_JH.94-100",
         "command": "../gpu_engine.sh ./lc0 --show-hidden",
         "restart": "on",
         "rating": "3542",

--- a/gpu/LCZero_GPU.json
+++ b/gpu/LCZero_GPU.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "LCZero v0.26.3+Tilps/dje_magic_JH.94-100",
+        "name": "LCZero 0.27.0d-Tilps-dje-magic_JH.94-100",
         "command": "../gpu_engine.sh ./lc0 --show-hidden",
         "restart": "on",
         "rating": "3542",

--- a/gpu/LCZero_GPU.json
+++ b/gpu/LCZero_GPU.json
@@ -1,6 +1,6 @@
 [
     {
-        "name": "LCZero v0.26.3_T60.66740",
+        "name": "LCZero v0.26.3_T60.SV.JH.94-100",
         "command": "../gpu_engine.sh ./lc0 --show-hidden",
         "restart": "on",
         "rating": "3542",
@@ -11,7 +11,7 @@
             },
             {
                 "name": "WeightsFile",
-                "value": "f8964c9ee5f01521dee5a021bed8317bab5b877f08cc5b40e9a0df2b356b9bfa"
+                "value": "J94-100"
             },
             {
                 "name": "Threads",

--- a/gpu/LCZero_GPU.json
+++ b/gpu/LCZero_GPU.json
@@ -30,6 +30,10 @@
                 "value": "20000000"
             },
             {
+                "name": "RamLimitMb",
+                "value": "96000"
+            },
+            {
                 "name": "MinibatchSize",
                 "value": "320"
             },

--- a/gpu/LCZero_GPU.json
+++ b/gpu/LCZero_GPU.json
@@ -27,7 +27,7 @@
             },
             {
                 "name": "NNCacheSize",
-                "value": "20000000"
+                "value": "50000000"
             },
             {
                 "name": "RamLimitMb",

--- a/gpu/update.sh
+++ b/gpu/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-git clone --recurse-submodules https://github.com/LeelaChessZero/lc0.git
+git clone --recurse-submodules https://github.com/Tilps/lc0.git
 cd lc0
-git checkout v0.26.3
+git checkout mgp_spinlocks_refactored
 read -p "Download done, press enter to continue"
 CC=clang-6.0 CXX=clang++-6.0 ./build.sh
 EXE=${PWD}/build/release/lc0

--- a/gpu/update.sh
+++ b/gpu/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-git clone --recurse-submodules https://github.com/Tilps/lc0.git
+git clone --recurse-submodules https://github.com/kiudee/lc0.git
 cd lc0
-git checkout mgp_spinlocks_refactored
+git checkout pr1483_sufi
 read -p "Download done, press enter to continue"
 CC=clang-6.0 CXX=clang++-6.0 ./build.sh
 EXE=${PWD}/build/release/lc0

--- a/gpu/update.sh
+++ b/gpu/update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 git clone --recurse-submodules https://github.com/kiudee/lc0.git
 cd lc0
-git checkout pr1483_sufi
+git checkout pr1483_sufi_fix
 read -p "Download done, press enter to continue"
 CC=clang-6.0 CXX=clang++-6.0 ./build.sh
 EXE=${PWD}/build/release/lc0


### PR DESCRIPTION
# Changes

1. Replaced 66740 with J94-100.
2. Use [PR1483](https://github.com/LeelaChessZero/lc0/pull/1483) to achieve a "modest" speed up on the TCEC hardware.
3. Introduce a `RamLimitMb` of 96 GB.
4. Increase `NNCacheSize` from 20M to 50M.